### PR TITLE
Add dark-mode logo swap and tweak CTA spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -107,6 +107,7 @@ textarea {
   .cta {
     display: inline-block;
     margin-top: 1rem;
+    margin-bottom: 1.5rem;
     background: var(--accent-color);
     color: white;
     padding: 0.75rem 1.5rem;
@@ -205,7 +206,7 @@ textarea {
 <body>
   <div class="container">
     <!-- Logo Placeholder -->
-    <img src="img/loia.png" alt="Loia Logo" class="logo" />
+    <img src="img/loia.png" alt="Loia Logo" class="logo" id="logo" />
     <!-- About Section -->
 <section class="section">
   <h2>About Loia</h2>
@@ -263,7 +264,6 @@ textarea {
       Start with Loia in the Custom GPT store or copy the raw prompt below to use in your favorite LLM:
     </p>
     <a href="" class="cta">Launch Loia on ChatGPT</a>
-<br><br>
   <div class="prompt-container">
     <button class="copy-button" onclick="copyPrompt()">Copy</button>
     <textarea id="prompt" readonly>
@@ -363,9 +363,19 @@ Music is architecture for emotion. Crossfade isn’t just a feature—it’s a b
     });
 
     const modeToggle = document.getElementById('mode-toggle');
+    const logo = document.getElementById('logo');
+
+    function updateLogo() {
+      const dark = document.body.classList.contains('dark-mode');
+      logo.src = dark ? 'img/loia-darkmode.png' : 'img/loia.png';
+      modeToggle.textContent = dark ? 'Light Mode' : 'Dark Mode';
+    }
+
     modeToggle.addEventListener('click', () => {
       document.body.classList.toggle('dark-mode');
-      modeToggle.textContent = document.body.classList.contains('dark-mode') ? 'Light Mode' : 'Dark Mode';
+      updateLogo();
     });
+
+    updateLogo();
   </script></body>
 </html>


### PR DESCRIPTION
## Summary
- add margin-bottom to CTA button for better spacing
- assign ID to logo image
- swap logo when toggling dark mode using JS
- update markup to remove unused `<br>` tags

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68795be4096883318ece766e13881541